### PR TITLE
Adding 'Development Status' to awesome.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,7 @@ Checklist for new projects:
 - [ ] Documentation looks great
 - [ ] Examples or Tutorials to follow
 - [ ] Tests and Travis CI running
+- [ ] Development status of the project is communicated
 
 <!-- For Datasets, Cheatsheets and Publications -->
 - [ ] Easily Accessible

--- a/awesome.md
+++ b/awesome.md
@@ -157,5 +157,9 @@ You can refer to the list of [trove classifiers defined by PyPI](https://pypi.or
     Awesome-ish: Your software is in terms of classifiers at least a 3 - Alpha but smaller than a 7 - Inactive
     Bad (not acceptable): Your software does not follow semantic versioning and you never thought 
                           about development status. Take 5 minutes of your time and become awesome-ish!
+
+*you can create custom badges i.e. on [shields.io](https://shields.io/)* 
+
+
 | ▲ [Top](#our-definition-of-awesome) |
 | --- |

--- a/awesome.md
+++ b/awesome.md
@@ -145,5 +145,14 @@ Tests can also be non-applicable for certain projects and are sometimes really h
     Awesome-ish (If we're in a really good mood): Documented manual steps that can be followed to objectively check the expected functionality of the software
 
 
+## Development Status
+
+Software can be in very different status and an awsome software will tell their users. `In-development` does not mean bad, because others might work on similar problems and this way you can join forces. However, code that is barly functional, claiming to cover a whole topic but offering only a fragment promised is not awesome. Nobody likes to end up with a `NotImplementedError` on every API endpoint.
+You can refer to the list of [trove classifiers defined by PyPI](https://pypi.org/classifiers/), which do also apply to other languages to indicate your development status. Additionally, it's absolutely awesome to stick to [semantic versioning](https://semver.org/).
+
+    Uber-Awesome: You are awesome and integrated the classifiers directly with PyPI making the software searchable via classifiers or if not applicable you have a classifier badge on the readme. 
+    Awesome: You are awsome-ish and your software uses semantic versioning and you indicate the development status prominently on your readme
+    Awesome-ish: Your software is in terms of classifiers at least a 3 - Alpha but smaller than a 7 - Inactive
+    Bad (not acceptable): Your software does not follow semantic versioning and you never thought about development status. Take 5 minutes of your time and become awesome-ish!
 | ▲ [Top](#our-definition-of-awesome) |
 | --- |

--- a/awesome.md
+++ b/awesome.md
@@ -150,9 +150,12 @@ Tests can also be non-applicable for certain projects and are sometimes really h
 Software can be in very different status and an awsome software will tell their users. `In-development` does not mean bad, because others might work on similar problems and this way you can join forces. However, code that is barly functional, claiming to cover a whole topic but offering only a fragment promised is not awesome. Nobody likes to end up with a `NotImplementedError` on every API endpoint.
 You can refer to the list of [trove classifiers defined by PyPI](https://pypi.org/classifiers/), which do also apply to other languages to indicate your development status. Additionally, it's absolutely awesome to stick to [semantic versioning](https://semver.org/).
 
-    Uber-Awesome: You are awesome and integrated the classifiers directly with PyPI making the software searchable via classifiers or if not applicable you have a classifier badge on the readme. 
-    Awesome: You are awsome-ish and your software uses semantic versioning and you indicate the development status prominently on your readme
+    Uber-Awesome: You are awesome and integrated the classifiers directly with PyPI making the software 
+                  searchable via classifiers or if not applicable you have a classifier badge on the readme. 
+    Awesome: You are awsome-ish and your software uses semantic versioning and you indicate the 
+             development status prominently on your readme
     Awesome-ish: Your software is in terms of classifiers at least a 3 - Alpha but smaller than a 7 - Inactive
-    Bad (not acceptable): Your software does not follow semantic versioning and you never thought about development status. Take 5 minutes of your time and become awesome-ish!
+    Bad (not acceptable): Your software does not follow semantic versioning and you never thought 
+                          about development status. Take 5 minutes of your time and become awesome-ish!
 | ▲ [Top](#our-definition-of-awesome) |
 | --- |

--- a/awesome.md
+++ b/awesome.md
@@ -147,7 +147,7 @@ Tests can also be non-applicable for certain projects and are sometimes really h
 
 ## Development Status
 
-Software can be in very different status and an awsome software will tell their users. `In-development` does not mean bad, because others might work on similar problems and this way you can join forces. However, code that is barly functional, claiming to cover a whole topic but offering only a fragment promised is not awesome. Nobody likes to end up with a `NotImplementedError` on every API endpoint.
+Software can be in very different status and an awsome software will tell their users. `In-development` does not mean bad, because others might work on similar problems and this way you can join forces. However, code that is barely functional, claiming to cover a whole topic but offering only a fragment promised is not awesome. Nobody likes to end up with a `NotImplementedError` on every API endpoint.
 You can refer to the list of [trove classifiers defined by PyPI](https://pypi.org/classifiers/), which do also apply to other languages to indicate your development status. Additionally, it's absolutely awesome to stick to [semantic versioning](https://semver.org/).
 
     Uber-Awesome: You are awesome and integrated the classifiers directly with PyPI making the software 

--- a/awesome.md
+++ b/awesome.md
@@ -158,7 +158,18 @@ You can refer to the list of [trove classifiers defined by PyPI](https://pypi.or
     Bad (not acceptable): Your software does not follow semantic versioning and you never thought 
                           about development status. Take 5 minutes of your time and become awesome-ish!
 
-*you can create custom badges i.e. on [shields.io](https://shields.io/)* 
+*you can create custom badges i.e. on [shields.io](https://shields.io/). Or you copy them from below:* 
+
+* ![](https://img.shields.io/badge/development%20status-1%20--%20Planning-red)
+* ![](https://img.shields.io/badge/development%20status-2%20--%20Pre--alpha-orange)
+* ![](https://img.shields.io/badge/development%20status-3%20--%20Alpha-yellow) 
+* ![](https://img.shields.io/badge/development%20status-4%20--%20Beta-yellowgreen) 
+* ![](https://img.shields.io/badge/development%20status-5%20--%20Production%2FStable-brightgreen)
+* ![](https://img.shields.io/badge/development%20status-6%20--%20Mature-success)
+* ![](https://img.shields.io/badge/development%20status-7%20--%20Inactive-inactive)
+
+
+
 
 
 | ▲ [Top](#our-definition-of-awesome) |


### PR DESCRIPTION
Resolves #6 

I am proposing two changes: A section on 'development status' of software in the `awesome.md` manifesto and an additional checkmark in the PR template (for the respective section).

My plan was to keep the dev status really inclusive and rely on PyPI's trove classifiers and semantic versioning. Links are given in the description of the new section.
