### PR TITLE
Updating travis-ci to fix certificate issues with awesome validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: ruby
 rvm: 2.4.1
 before_script: gem install awesome_bot


### PR DESCRIPTION
Travis uses Ubuntu 16.04 as default build environment.

This is no longer supported by Ubuntu, and new root certificates seem to not be available anymore.

As a result the awesomebot validator can no longer access all needed root certificates and fails. This PR bumps the travis build environment to 18.04.
